### PR TITLE
langgraph-sdk 0.1.70 :snowflake:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,9 @@ requirements:
     - python
     - httpx >=0.25.2
     - orjson >=3.10.1
+    # import failed with -> ModuleNotFoundError: No module named 'typing_extensions'
+    # https://github.com/langchain-ai/langgraph/blob/0.4.7/libs/sdk-py/langgraph_sdk/auth/types.py#L19
+    - typing_extensions
 
 test:
   imports:
@@ -32,8 +35,6 @@ test:
     - pip check
   requires:
     - pip
-    # import failed with -> ModuleNotFoundError: No module named 'typing_extensions'
-    - typing_extensions
 
 about:
   home: https://www.github.com/langchain-ai/langgraph

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,9 @@ test:
   imports:
     - langgraph_sdk
     - langgraph_sdk.auth
+    - langgraph_sdk.client
+    - langgraph_sdk.schema
+    - langgraph_sdk.sse
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,28 +6,28 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/langgraph_sdk-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: cc65ec33bcdf8c7008d43da2d2b0bc1dd09f98d21a7f636828d9379535069cf9
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<39]
 
 requirements:
   host:
-    - python >=3.9,<4.0
-    - hatchling
+    - python
     - pip
+    - hatchling
   run:
-    - python >=3.9.0,<4.0.0,<4.0
+    - python
     - httpx >=0.25.2
-    - httpx-sse >=0.4.0
     - orjson >=3.10.1
 
 test:
   imports:
     - langgraph_sdk
+    - langgraph_sdk.auth
   commands:
     - pip check
   requires:
@@ -37,7 +37,11 @@ about:
   home: https://www.github.com/langchain-ai/langgraph
   summary: SDK for interacting with LangGraph API
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  description: This repository contains the Python SDK for interacting with the LangGraph Platform REST API.
+  dev_url: https://github.com/langchain-ai/langgraph/tree/main/libs/sdk-py
+  doc_url: https://github.com/langchain-ai/langgraph/blob/main/libs/sdk-py/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ test:
     - pip check
   requires:
     - pip
+    # import failed with -> ModuleNotFoundError: No module named 'typing_extensions'
+    - typing_extensions
 
 about:
   home: https://www.github.com/langchain-ai/langgraph


### PR DESCRIPTION
langgraph-sdk 0.1.70 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8292]
- dev_url:        https://github.com/langchain-ai/langgraph/tree/0.4.7/libs/sdk-py
- conda_forge:    https://github.com/conda-forge/langgraph-sdk-feedstock
- pypi:           https://pypi.org/project/langgraph-sdk/0.1.70
- pypi inspector: https://inspector.pypi.io/project/langgraph-sdk/0.1.70/

### Explanation of changes:

- new version number


[PKG-8292]: https://anaconda.atlassian.net/browse/PKG-8292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ