### PR TITLE
langgraph-sdk 0.2.9 release to main

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     folder: gh_src
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<39]
 


### PR DESCRIPTION
langgraph-sdk 0.2.9 

**Destination channel:** Defaults

### Links

- [PKG-10346]
- dev_url:        https://github.com/langchain-ai/langgraph/tree/sdk==0.2.9
- conda_forge:    https://github.com/conda-forge/langgraph-sdk-feedstock
- pypi:           https://pypi.org/project/langgraph-sdk/0.2.9
- pypi inspector: https://inspector.pypi.io/project/langgraph-sdk/0.2.9

### Explanation of changes:

- langgraph-sdk is already on snowflake channel, this is dependency for langgraph


[PKG-10346]: https://anaconda.atlassian.net/browse/PKG-10346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ